### PR TITLE
feat: CreateStubs Pre/Post Processing Script

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,6 +4,9 @@
 
 # Patch Branches
 PATCHES=`git for-each-ref refs/heads/patch --format='%(refname)' | cut -d/ -f3-`
+## Remove current branch (in the case of making a patch branch)
+CUR_BRANCH=`git branch --show-current`
+PATCHES=( ${PATCHES[@]/$CUR_BRANCH} )
 
 # Update Patches
 ROOT=`git rev-parse --show-toplevel`

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,12 +7,13 @@ PATCHES=`git for-each-ref refs/heads/patch --format='%(refname)' | cut -d/ -f3-`
 
 # Update Patches
 ROOT=`git rev-parse --show-toplevel`
+SCRIPT="$ROOT/createstubs.py"
 
 # Make Patches
 for patch in "${PATCHES[@]}"; do
 	NAME=`echo $patch | cut -c 7-`
 	OUT="$ROOT/patches/$NAME.patch"
-	git format-patch --stdout --root "$patch" -1 > "$OUT"
+	git format-patch -1 "$patch" "$SCRIPT" --no-signature --stdout > "$OUT"
 	# Stage
 	git add "$OUT"
 done

--- a/createstubs.py
+++ b/createstubs.py
@@ -260,13 +260,11 @@ class Stubber():
         try:
             # write json by node to reduce memory requirements
             with open(f_name, 'w') as f:
-                print('starting header')
                 f.write('{')
                 f.write(dumps(self._report_fwi)[1:-1])
                 f.write(',')
                 f.write(dumps(self._report_stb)[1:-1])
                 f.write(',')
-                print('starting modules')
                 f.write('"modules" :[')
                 start = True
                 for n in self._report:
@@ -274,9 +272,7 @@ class Stubber():
                         start = False
                     else:
                         f.write(',')
-                    print('starting mod')
                     f.write(dumps(n))
-                print('almost done')
                 f.write(']}')
         except:
             self._log.error("Failed to create the report.")

--- a/patches/esp8266-no-spiram.patch
+++ b/patches/esp8266-no-spiram.patch
@@ -1,15 +1,14 @@
-From aa2aeec826506ce2e7aa3b5138b9a2257d823b41 Mon Sep 17 00:00:00 2001
+From c1c0d5ad105c0f1941e36bbd1c966b8760abd76d Mon Sep 17 00:00:00 2001
 From: Braden Mars <BradenM@users.noreply.github.com>
-Date: Tue, 16 Jul 2019 17:00:35 -0500
-Subject: [PATCH] feat: Support for ESP8266 without SPIRam
+Date: Wed, 17 Jul 2019 01:25:20 -0500
+Subject: [PATCH] feat(patch): ESP8266 No SPIRam Patch
 
 ---
- createstubs.py                  | 22 ++++++++--------------
- patches/esp8266-no-spiram.patch | 25 +++++++++++++------------
- 2 files changed, 21 insertions(+), 26 deletions(-)
+ createstubs.py | 19 ++++++++-----------
+ 1 file changed, 8 insertions(+), 11 deletions(-)
 
 diff --git a/createstubs.py b/createstubs.py
-index cb5765b..162dcc1 100644
+index ad71c8f..a9b73c1 100644
 --- a/createstubs.py
 +++ b/createstubs.py
 @@ -46,8 +46,8 @@ class Stubber():
@@ -36,7 +35,7 @@ index cb5765b..162dcc1 100644
              if module_name in self.problematic:
                  self._log.warning("Skip module: {:<20}        : Known problematic".format(module_name))
                  continue
-@@ -122,19 +122,13 @@ class Stubber():
+@@ -122,13 +122,10 @@ class Stubber():
  
      def create_module_stub(self, module_name: str, file_name: str = None):
          "Create a Stub of a single python module"
@@ -53,52 +52,3 @@ index cb5765b..162dcc1 100644
          if '/' in module_name:
              #for nested modules
              self.ensure_folder(file_name)
--            module_name = module_name.replace('/', '.')
--            if not self.include_nested:
--                self._log.warning("SKIPPING nested module:{}".format(module_name))
-                 return
- 
-         if file_name is None:
-diff --git a/patches/esp8266-no-spiram.patch b/patches/esp8266-no-spiram.patch
-index 22e7b56..9d4e6be 100644
---- a/patches/esp8266-no-spiram.patch
-+++ b/patches/esp8266-no-spiram.patch
-@@ -1,18 +1,16 @@
-+From 64a15f975586c09584edb61fb391e16256385a16 Mon Sep 17 00:00:00 2001
-+From: Braden Mars <BradenM@users.noreply.github.com>
-+Date: Tue, 16 Jul 2019 17:00:35 -0500
-+Subject: [PATCH] feat: Support for ESP8266 without SPIRam
-+
-+---
-+ createstubs.py | 15 ++++++---------
-+ 1 file changed, 6 insertions(+), 9 deletions(-)
-+
- diff --git a/createstubs.py b/createstubs.py
--index cb5765b..17896ae 100644
-+index cb5765b..0b3a62f 100644
- --- a/createstubs.py
- +++ b/createstubs.py
--@@ -46,8 +46,8 @@ class Stubber():
--             self.ensure_folder(path + "/")
--         except:
--             self._log.error("error creating stub folder {}".format(path))
---        self.problematic = ["upysh", "webrepl_setup", "http_client", "http_client_ssl", "http_server", "http_server_ssl"]
---        self.excluded = ["webrepl", "_webrepl", "webrepl_setup"]
--+        self.problematic = ["upysh", "webrepl", "_webrepl", "webrepl_setup", "http_client", "http_client_ssl", "http_server", "http_server_ssl"]
--+        self.excluded = [ "port_diag","example_sub_led.py","example_pub_button.py"]
--         # there is no option to discover modules from upython, need to hardcode
--         # below contains the combines modules from  Micropython ESP8622, ESP32 and Loboris Modules
--         self.modules = ['_boot', '_onewire', '_thread', '_webrepl', 'ak8963', 'apa102', 'apa106', 'array', 'binascii', 'btree', 'builtins', 'upip', #do upip early
- @@ -94,9 +94,9 @@ class Stubber():
-              if self.include_nested:
-                  self.include_nested = gc.mem_free() > 3200
-@@ -43,3 +41,6 @@ index cb5765b..17896ae 100644
-          if '/' in module_name:
-              #for nested modules
-              self.ensure_folder(file_name)
-+-- 
-+2.22.0
-+
--- 
-2.22.0
-

--- a/patches/esp8266-no-spiram.patch
+++ b/patches/esp8266-no-spiram.patch
@@ -1,0 +1,45 @@
+diff --git a/createstubs.py b/createstubs.py
+index cb5765b..17896ae 100644
+--- a/createstubs.py
++++ b/createstubs.py
+@@ -46,8 +46,8 @@ class Stubber():
+             self.ensure_folder(path + "/")
+         except:
+             self._log.error("error creating stub folder {}".format(path))
+-        self.problematic = ["upysh", "webrepl_setup", "http_client", "http_client_ssl", "http_server", "http_server_ssl"]
+-        self.excluded = ["webrepl", "_webrepl", "webrepl_setup"]
++        self.problematic = ["upysh", "webrepl", "_webrepl", "webrepl_setup", "http_client", "http_client_ssl", "http_server", "http_server_ssl"]
++        self.excluded = [ "port_diag","example_sub_led.py","example_pub_button.py"]
+         # there is no option to discover modules from upython, need to hardcode
+         # below contains the combines modules from  Micropython ESP8622, ESP32 and Loboris Modules
+         self.modules = ['_boot', '_onewire', '_thread', '_webrepl', 'ak8963', 'apa102', 'apa106', 'array', 'binascii', 'btree', 'builtins', 'upip', #do upip early
+@@ -94,9 +94,9 @@ class Stubber():
+             if self.include_nested:
+                 self.include_nested = gc.mem_free() > 3200
+ 
+-            if module_name.startswith("_") and module_name != '_thread':
+-                self._log.warning("Skip module: {:<20}        : internal ".format(module_name))
+-                continue
++            # if module_name.startswith("_") and module_name != '_thread':
++            #     self._log.warning("Skip module: {:<20}        : internal ".format(module_name))
++            #     continue
+             if module_name in self.problematic:
+                 self._log.warning("Skip module: {:<20}        : Known problematic".format(module_name))
+                 continue
+@@ -122,13 +122,10 @@ class Stubber():
+ 
+     def create_module_stub(self, module_name: str, file_name: str = None):
+         "Create a Stub of a single python module"
+-        if module_name.startswith("_") and module_name != '_thread':
+-            self._log.warning("SKIPPING internal module:{}".format(module_name))
+-            return
+ 
+-        if module_name in self.problematic:
+-            self._log.warning("SKIPPING problematic module:{}".format(module_name))
+-            return
++        if file_name is None: 
++            file_name = module_name.replace('.', '/') + ".py"
++
+         if '/' in module_name:
+             #for nested modules
+             self.ensure_folder(file_name)

--- a/patches/pycom.patch
+++ b/patches/pycom.patch
@@ -1,0 +1,22 @@
+From 7566ae4a317e4228ef0e9f333965d0225bb76c5a Mon Sep 17 00:00:00 2001
+From: Braden Mars <BradenM@users.noreply.github.com>
+Date: Fri, 26 Jul 2019 00:27:48 -0500
+Subject: [PATCH] feat(patch): PyCom Modules Patch
+
+---
+ createstubs.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/createstubs.py b/createstubs.py
+index ad71c8f..d848891 100644
+--- a/createstubs.py
++++ b/createstubs.py
+@@ -58,7 +58,7 @@ class Stubber():
+                         'select', 'socket', 'socketupip', 'ssd1306', 'ssh', 'ssl', 'struct', 'sys', 'time', 'tpcalib', 'uasyncio', 'uasyncio/core', 'ubinascii',
+                         'ucollections', 'ucryptolib', 'uctypes', 'uerrno', 'uhashlib', 'uheapq', 'uio', 'ujson', 'umqtt/robust', 'umqtt/simple', 'uos', 'upip_utarfile',
+                         'upysh', 'urandom', 'ure', 'urequests', 'urllib/urequest', 'uselect', 'usocket', 'ussl', 'ustruct', 'utime', 'utimeq', 'uwebsocket', 'uzlib', 'webrepl',
+-                        'webrepl_setup', 'websocket', 'websocket_helper', 'writer', 'ymodem', 'zlib']
++                        'webrepl_setup', 'websocket', 'websocket_helper', 'writer', 'ymodem', 'zlib', 'pycom', 'crypto']
+ 
+         #try to avoid running out of memory with nested mods
+         self.include_nested = gc.mem_free() > 3200

--- a/process.py
+++ b/process.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Pre/Post Processing for createstubs.py
+
+commands:
+  minify                 Create minified version of createstubs.py
+
+"""
+
+import argparse
+import re
+import sys
+from optparse import Values
+from pathlib import Path
+
+# Pyminifier Dep
+token_utils = None
+minification = None
+try:
+    from pyminifier import token_utils, minification
+except ImportError:
+    pass
+
+ROOT = Path(__file__).parent
+SCRIPT = ROOT / 'createstubs.py'
+PATCHES = ROOT / 'patches'
+
+
+def apply_patch(s, patch, revert=False):
+    """
+    Apply patch to string s to recover newer string.
+    If revert is True, treat s as the newer string, recover older string.
+
+    Credits:
+    Isaac Turner 2016/12/05
+    https://gist.github.com/noporpoise/16e731849eb1231e86d78f9dfeca3abc
+    """
+    _hdr_pat = re.compile(r"@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@")
+    s = s.splitlines(True)
+    p = patch.splitlines(True)
+    t = ''
+    i = sl = 0
+    (midx, sign) = (1, '+') if not revert else (3, '-')
+    while i < len(p) and not p[i].startswith("@@"):
+        i += 1  # skip header lines
+    while i < len(p):
+        m = _hdr_pat.match(p[i])
+        if not m:
+            raise Exception("Bad patch -- regex mismatch [line "+str(i)+"]")
+        l = int(m.group(midx))-1 + (m.group(midx+1) == '0')
+        if sl > l or l > len(s):
+            raise Exception("Bad patch -- bad line num [line "+str(i)+"]")
+        t += ''.join(s[sl:l])
+        sl = l
+        i += 1
+        while i < len(p) and p[i][0] != '@':
+            if i+1 < len(p) and p[i+1][0] == '\\':
+                line = p[i][:-1]
+                i += 2
+            else:
+                line = p[i]
+                i += 1
+            if len(line) > 0:
+                if line[0] == sign or line[0] == ' ':
+                    t += line[1:]
+                sl += (line[0] != sign)
+    t += ''.join(s[sl:])
+    return t
+
+
+def edit_lines(content, edits):
+    """Edit string by list of edits
+
+    Args:
+        content (str): content to edit
+        edits ([(str, str)]): List of edits to make.
+            The first string in the tuple represents
+            the type of edit to make, can be either:
+                comment - comment text out (removed on minify)
+                rprint - replace text with print
+                rpass - replace text with pass
+            The second string is the matching text to replace
+
+    Returns:
+        str: edited string
+    """
+    def comment(l, x): return l.replace(x, f"# {x}")
+    def rprint(l, x): return l.replace(x, f"print")
+    def rpass(l, x): return l.replace(x, f"pass")
+    lines = []
+    for line in content.splitlines(keepends=True):
+        for edit, text in edits:
+            func = eval(edit)
+            line = func(line, text)
+        lines.append(line)
+    stripped = "".join(lines)
+    return stripped
+
+
+def minify_script(patches=None):
+    """minifies createstubs.py
+
+    Args:
+        patches ([PathLike], optional): List of paths to patches to apply.
+            Defaults to None.
+
+    Returns:
+        str: minified source text
+    """
+    patches = patches or []
+    edits = [
+        ("comment", "import logging"),
+        ("comment", "self._log ="),
+        ("rpass",
+         'self._log.debug("could not del modules[{}]".format(module_name))'),
+        ("comment", "self._log.debug"),
+        ("rprint", "self._log.warning"),
+        ("rprint", "self._log.info"),
+        ("rprint", "self._log.error"),
+    ]
+    minopts = Values({'tabs': False})
+    with SCRIPT.open('r') as f:
+        content = f.read()
+        for path in patches:
+            with path.open('r') as p:
+                content = apply_patch(content, p.read())
+        content = edit_lines(content, edits)
+        tokens = token_utils.listified_tokenizer(content)
+        source = minification.minify(tokens, minopts)
+    return source
+
+
+def get_patches():
+    """Iterate patch files"""
+    for f in PATCHES.iterdir():
+        yield (f.stem, f.resolve())
+
+
+def cli_minify(**kwargs):
+    """minify cli handler"""
+    print("\nMinifying createstubs.py...")
+    out = kwargs.pop("dest")
+    patches = kwargs.pop("patches")
+    patch_paths = []
+    if not minification:
+        print("\npyminification is required to minify createstubs.py\n")
+        print("Please install via:\n  pip install pyminification")
+        sys.exit(1)
+    for name, path in patches:
+        if path is None:
+            print(f"Cannot find patch: {name}")
+            print("\nAvailable Patches:")
+            print("\n".join(p[0] for p in get_patches()))
+            sys.exit(0)
+        print(f"Applying Patch: {name}")
+        patch_paths.append(path)
+    with out.open('w+') as f:
+        source = minify_script(patch_paths)
+        f.write(source)
+    print("\nDone!")
+    print(f"Minified file written to: {out}")
+
+
+if __name__ == "__main__":
+    class HelpTextFormatter(argparse.RawDescriptionHelpFormatter):
+        """Help Text Formatter
+        Credit - https://stackoverflow.com/a/35925919
+        """
+
+        def __add_whitespace(self, idx, iWSpace, text):
+            if idx == 0:
+                return text
+            return (" " * iWSpace) + text
+
+    patches = list(get_patches())
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=HelpTextFormatter)
+    parser.add_argument('command', nargs='+', help="Command to execute")
+    parser.add_argument('-p', '--patch',
+                        action='append',
+                        type=lambda x:
+                        next((p
+                              for p in patches if p[0] == x), (x, None)),
+                        help="Apply a patch to createstubs.py",
+                        default=[]
+                        )
+    parser.add_argument(
+        "-d", "--dest",
+        help="Specify file to output to. Defaults to minified.py",
+        type=Path,
+        default=(ROOT / 'minified.py'))
+    args = parser.parse_args()
+    cmd = args.command.pop(0)
+    func = eval(f"cli_{cmd}")
+    func(patches=args.patch, opts=args.command, dest=args.dest)

--- a/process.py
+++ b/process.py
@@ -278,8 +278,8 @@ def cli_minify(**kwargs):
     out = kwargs.pop("output")
     patches = kwargs.pop("patch")
     if not minification:
-        print("\npyminification is required to minify createstubs.py\n")
-        print("Please install via:\n  pip install pyminification")
+        print("\pyminifier is required to minify createstubs.py\n")
+        print("Please install via:\n  pip install pyminifier")
         sys.exit(1)
     patch_paths = resolve_patches(patches)
     with out.open('w+') as f:

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,8 @@ The stub files are generated on a micropython board by running the script `creat
 this will generate the stubs on the board, either on flash or on the SD card.
 The generation will take a few minutes ( 2-5 minutes) depending on the speed of the board and the number of included modules.
 
+As the stubs are generated on the board, and as MicroPython is highly optimised to deal with the scarce resources, this unfortunately does mean that the stubs lack parameters details. So for these you must still use the documentation provided for that firmware.
+
 After this is completed, you will need to download the generated stubs from the micropython board, and save them on a folder on your computer. 
 if you work with multiple firmwares or versions it is recommended to use a folder name combining the firmware name and version
 - \stubs
@@ -127,7 +129,7 @@ if you work with multiple firmwares or versions it is recommended to use a folde
 Note: I found out that you need to be mindful of the maximum path and filename limitations on the filesystem if you use IFSS.
 
 ## Frozen Modules 
-it is common for Firmwares to include a few (or many) modules as 'frozen' modules. This a way to pre-process .py modules so they're 'baked-in' to MicroPython's firmware and use less memory. Once the code is frozen it can be quickly loaded and interpreted by MicroPython without as much memory and processing time.
+It is common for Firmwares to include a few (or many) modules as 'frozen' modules. This a way to pre-process .py modules so they're 'baked-in' to MicroPython's firmware and use less memory. Once the code is frozen it can be quickly loaded and interpreted by MicroPython without as much memory and processing time.
 
 Most OSS firmwares store these frozen modules as part of their repository, which allows us to: 
 1. Download the *.py from the (github) repo using `git clone` or a direct download 


### PR DESCRIPTION
Adds `process.py`, a small script to handle pre/post processing for `createstubs.py`

Current Usage:

`./process.py minify`

* Removes Logging Dep
* Removes Debug Log calls
* Changes warning/info/error debug calls to print calls
* Executes `pyminifier` to minify
* Outputs file to `-d/--dest` option (defaults to `minified.py`)

`./process.py minify -p esp8266-no-spiram -p <PATCHNAME>...` 

* Same as above
* Loads patch files from ./patches directory
* Applies each `-p <NAME>` patchfile before minification.

Its setup to where any other commands can be added easily if needed.

Also keeps any Cli interface code seperate from main code, so it can just as easily be used like so:
```python
import process

patches = ["foobar/bar.patch", "bar/foo.patch"]
# Returns createstubs.py  as patched/minified string
min_source = process.minify_script(patches=patches)
```