### PR TITLE
fix: Monkey Patch os.uname method if undefined

### DIFF
--- a/createstubs.py
+++ b/createstubs.py
@@ -40,6 +40,13 @@ class Stubber():
                 release = kwargs.pop('release', '0.0.0'),
                 version = kwargs.pop('version', '0.0.0'),
                 machine = kwargs.pop('machine', 'generic')
+
+                def __repr__(self):
+                    _attrs = ['sysname', 'nodename',
+                              'release', 'version', 'machine']
+                    attrs = ["{}={}".format(a, getattr(self, a))
+                             for a in _attrs]
+                    return "{}".format(", ".join(attrs))
             # monkeypatch uname to allow stub creation to take place
             os.uname = UnameStub
         finally:


### PR DESCRIPTION
The issue in #7 was related to a version of `micropython` that does not have the `os.uname` function. In this case, an exception was being raised [here](https://github.com/Josverl/micropython-stubber/blob/8930e8a0038192fd259b31a193d1da3b2501256a/createstubs.py#L174) (prior usage of `os.uname` had been changed to hard-coded values) and was being hidden by [this try/except block.](https://github.com/Josverl/micropython-stubber/blob/8930e8a0038192fd259b31a193d1da3b2501256a/createstubs.py#L118)

This fix checks if `os.uname` exists, and if not it will monkey patch it with a `UnameStub` class.

By default this will alarm the user via a `self._log.info` call and use "generic" values in substitution for the normal `os.uname` values. 

This behavior can be overridden by providing the additional information as so:

```py
device_info = {'sysname': 'ev3', 'nodename':'ev3', 'release':'v1.0.0', 'machine':'ev3'}

stubber = Stubber(path="/home/robot/stubs", firmware_id="LEGO EV3 v1.0.0", **device_info)
```

Unfortunately, this might be the only solution to this issue as no other built-in function call that I am aware of seem to provide information at the same level of detail.

I don't think this will be a common issue, however, as the pybricks firmware was actually just (a customized) Unix port of `micropython-1.9.4` running on their custom `ev3dev` linux kernel. Not something most py-devices opt to do. 

Another fun and unintentional side effect of this PR is that it makes it much easier to test `createstubs.py` on your host machine, as it is now compatible with the Unix port :)
Ran fine on `micropython v1.11` built via [pyenv](https://github.com/pyenv/pyenv).
