### PR TITLE
Catch unknown errors when parsing files

### DIFF
--- a/runOnPc/make_stub_files.py
+++ b/runOnPc/make_stub_files.py
@@ -1629,6 +1629,7 @@ class StandAloneMakeStubFile:
         # out_fn = os.path.join(self.output_directory, base_fn)
         # out_fn = out_fn[:-3] + '.pyi'
         out_fn = fn + 'i'
+        self.output_fn = os.path.normpath(out_fn)
         try:
             s = open(fn).read()
             node = ast.parse(s,filename=fn,mode='exec')

--- a/runOnPc/make_stub_files.py
+++ b/runOnPc/make_stub_files.py
@@ -1629,10 +1629,13 @@ class StandAloneMakeStubFile:
         # out_fn = os.path.join(self.output_directory, base_fn)
         # out_fn = out_fn[:-3] + '.pyi'
         out_fn = fn + 'i'
-        self.output_fn = os.path.normpath(out_fn)
-        s = open(fn).read()
-        node = ast.parse(s,filename=fn,mode='exec')
-        StubTraverser(controller=self).run(node)
+        try:
+            s = open(fn).read()
+            node = ast.parse(s,filename=fn,mode='exec')
+            StubTraverser(controller=self).run(node)
+        except:
+            print('Unexpected error occurred whilst parsing file %s:' % fn, sys.exc_info()[0])
+
 
     def run(self):
         '''


### PR DESCRIPTION
I run MacOs 10.14 and when running the stubber as part of micropython-cli i received UnicodeDecodeErros when trying to read some files.  When this happens, the error would crash the stubber. 

This pull requests adds a try/except block around the file read so that if an unknown error is thrown, the stubber can continue with the remaining files.

TO reproduce this, try the following:
1. Install micropy-cli
1. setup a new projct
1. execute `micropy install cyrusbus`

this throws the following stack trace 

```
Traceback (most recent call last):
  File "/usr/local/bin/micropy", line 11, in <module>
    load_entry_point('micropy-cli', 'console_scripts', 'micropy')()
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/cli.py", line 136, in install
    reqs = project.add_from_requirements()
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/project/project.py", line 266, in add_from_requirements
    reqs = self._add_pkgs_from_file(self.requirements)
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/project/project.py", line 257, in _add_pkgs_from_file
    self.add_package(req.line, **kwargs)
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/project/project.py", line 240, in add_package
    self.load_packages()
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/project/project.py", line 165, in load_packages
    self._fetch_package(tar_url)
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/project/project.py", line 142, in _fetch_package
    stubs = [utils.generate_stub(f) for f in py_files]
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/project/project.py", line 142, in <listcomp>
    stubs = [utils.generate_stub(f) for f in py_files]
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/utils/helpers.py", line 228, in generate_stub
    ctrl.run()
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/lib/stubber/runOnPc/make_stub_files.py", line 1652, in run
    self.make_stub_file(fn)
  File "/Users/james/Documents/Dev/start-system/src/micropy-cli/micropy/lib/stubber/runOnPc/make_stub_files.py", line 1634, in make_stub_file
    s = open(fn).read()
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x88 in position 37: invalid start byte
```

This PR fixes this error.
