### PR TITLE
fix(utils): `utils.readconfig` module export throws `FileNotFound` when outside of root directory.

### DIFF
--- a/src/stubber/utils/__init__.py
+++ b/src/stubber/utils/__init__.py
@@ -1,5 +1,4 @@
 # type: ignore
-from .config import readconfig
 from .manifest import make_manifest, manifest
 from .post import do_post_processing
 from .stubmaker import generate_pyi_files, generate_pyi_from_file


### PR DESCRIPTION
The top-level `.utils.version` import in the package `__init__.py` causes the `utils.readconfig` import to trigger during import and/or import of any submodules.

When you are not in the repository root directory, this throws a `FileNotFound` exception.

This prevents usage of micropython-stubber as a library.
