### PR TITLE
feat(board): include `board/createstubs.py` and add `stubber.board` module for programmatic usage.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
 ]
 packages = [{ include = "**/*.*", from = "src" }]
-include = []
+include = [
+    "board/createstubs.py"
+]
 exclude = [
     "**/tests/**",
     "**/*-test",

--- a/src/stubber/board.py
+++ b/src/stubber/board.py
@@ -1,0 +1,13 @@
+import importlib.util
+from pathlib import Path
+
+__all__ = ["create_stubs"]
+
+_origin = Path(importlib.util.find_spec("stubber").origin)  # type: ignore
+
+create_stubs = _origin.parent.parent / "board" / "createstubs.py"
+
+_editable_root = _origin.parent.parent.parent
+_editable_create = _editable_root / "board" / "createstubs.py"
+if _editable_create.exists():
+    create_stubs = _editable_create


### PR DESCRIPTION
Including the core `boards/createstubs.py` in the package dist/wheel opens the door for easy use as a library when in combination with `stubber.minify` (see #293 as well)

This just adds a simple `stubber.boards` module with a top level variable `create_stubs` that resolves the correct path whether in an editable install or a packaged install.
