### PR TITLE
Dynamically generate createstubs flavors and/or module lists via codemods.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ exclude = '''
         | tests[\\/]rst[\\/]data
         | tests[\\/]codemods[\\/]codemod_test_cases
         | scratch
+        | src[\\/]stubber[\\/]codemod[\\/]_partials
     )/
 )
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,8 @@ omit = [
     "*/make_stub_files.py",
     "*/stubber/tools/*.py",
 
+    # codemod partials
+    "*/codemod/_partials"
 
 ]
 

--- a/src/stubber/codemod/_partials/__init__.py
+++ b/src/stubber/codemod/_partials/__init__.py
@@ -1,0 +1,37 @@
+from collections import deque
+from enum import Enum
+from pathlib import Path
+from typing import Iterator
+
+PARTIALS_DIR = Path(__file__).parent.absolute()
+
+PARTIAL_START = "###PARTIAL###"
+PARTIAL_END = "###PARTIALEND###"
+
+
+def _read_partial(path: Path) -> Iterator[str]:
+    lines = deque(path.read_text().splitlines(keepends=True))
+    _start = False
+    _end = False
+    while True:
+        if not _start and (line := lines.popleft()):
+            _start = line.strip() == PARTIAL_START
+        if not _end and (line := lines.pop()):
+            _end = line.strip() == PARTIAL_END
+        if _start and _end:
+            break
+    yield from lines
+
+
+class Partial(Enum):
+    DB_ENTRY = "db_entry"
+
+    @property
+    def partial_path(self) -> Path:
+        return (PARTIALS_DIR / self.value).with_suffix(".py")
+
+    def contents(self) -> str:
+        return "".join(_read_partial(self.partial_path))
+
+
+__all__ = ["Partial"]

--- a/src/stubber/codemod/_partials/db_entry.py
+++ b/src/stubber/codemod/_partials/db_entry.py
@@ -1,0 +1,90 @@
+from typing import TYPE_CHECKING, type_check_only
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    @type_check_only
+    class Stubber:
+        path: str
+
+    @type_check_only
+    def read_path() -> str: ...
+
+    @type_check_only
+    class _gc():
+        def collect(self) -> None:
+
+
+    gc: _gc
+    _log: Logger
+
+
+
+###PARTIAL###
+def main():
+    import machine  # type: ignore
+
+    try:
+        f = open("modulelist" + ".done", "r+b")
+        was_running = True
+        _log.info("Opened existing db")
+    except OSError:
+        f = open("modulelist" + ".done", "w+b")
+        _log.info("created new db")
+        was_running = False
+
+    stubber = Stubber(path=read_path())
+    if not was_running:
+        # Only clean folder if this is a first run
+        stubber.clean()
+
+    # get list of modules to process
+    with open("modulelist" + ".txt") as f:
+        # not optimal , but works on mpremote and esp8266
+        modules = [l.strip() for l in f.read().split("\\n") if len(l.strip()) and l.strip()[0] != "#"]
+    gc.collect()
+    # remove the ones that are already done
+    modules_done = {}  # type: dict[str, str]
+    try:
+        with open("modulelist" + ".done") as f:
+            # not optimal , but works on mpremote and esp8266
+            for line in f.read().split("\\n"):
+                line = line.strip()
+                gc.collect()
+                if len(line) > 0:
+                    key, value = line.split("=", 1)
+                    modules_done[key] = value
+
+    except (OSError, SyntaxError):
+        pass
+
+    gc.collect()
+    modules = [m for m in modules if m not in modules_done.keys()]
+    gc.collect()
+
+    for modulename in modules:
+        # ------------------------------------
+        # do epic shit
+        # but sometimes things fail
+        ok = False
+        try:
+            ok = stubber.create_one_stub(modulename)
+        except MemoryError:
+            # RESET AND HOPE THAT IN THE NEXT CYCLE WE PROGRESS FURTHER
+            machine.reset()
+
+        # save the (last) result back to the database/result file
+        if ok:
+            result = stubber._report[-1]
+        else:
+            result = "failed"
+        # -------------------------------------
+        modules_done[modulename] = str(result)
+        with open("modulelist" + ".done", "a") as f:
+            f.write("{}={}\n".format(modulename, result))
+
+    # Finished processing - load all the results , and remove the failed ones
+    if len(modules_done) > 0:
+        stubber._report = [v for k, v in modules_done.items() if v != "failed"]
+        stubber.report()
+###PARTIALEND###

--- a/src/stubber/codemod/board.py
+++ b/src/stubber/codemod/board.py
@@ -171,8 +171,10 @@ class LVGLCodemod(codemod.Codemod):
         modules_transform = modules_transform or self.context.scratch.get("modules_transform")
         if modules_transform and not isinstance(modules_transform, ModulesUpdateCodemod):
             raise TypeError(f"modules_transform must be of type ModulesUpdateCodemod, received: {type(modules_transform)}")
-        self.modules_transform = modules_transform or ModulesUpdateCodemod(
-            self.context, modules=ListChangeSet.from_strings(add=["io", "lodepng", "rtch", "lvgl"], replace=True)
+        self.modules_transform = (
+            modules_transform
+            if modules_transform and modules_transform.modules_changeset
+            else ModulesUpdateCodemod(self.context, modules=ListChangeSet.from_strings(add=["io", "lodepng", "rtch", "lvgl"], replace=True))
         )
         self.init_node = init_node or cst.parse_module(_LVGL_MAIN)
 

--- a/src/stubber/codemod/board.py
+++ b/src/stubber/codemod/board.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from enum import Enum, unique, auto
+from typing import Optional
+
+import libcst as cst
+import libcst.codemod as codemod
+from libcst import matchers as m
+
+from stubber.codemod.modify_list import ModifyListElements, ListChangeSet
+from stubber.cst_transformer import update_module_docstr
+
+_STUBBER_MATCHER = m.Assign(
+    targets=[
+        m.AssignTarget(
+            target=m.Name("stubber"),
+        )
+    ],
+    value=m.Call(func=m.Name("Stubber")),
+)
+
+_MODULES_MATCHER = m.Assign(
+    targets=[
+        m.AssignTarget(
+            target=m.Attribute(
+                value=m.Name(value="stubber"),
+                attr=m.Name(value="modules"),
+            ),
+        )
+    ],
+)
+
+_MODULES_READER = """
+# Read stubs from modulelist
+try:
+    with open("modulelist" + ".txt") as f:
+        # not optimal , but works on mpremote and eps8266
+        stubber.modules = [l.strip() for l in f.read().split("\\n") if len(l.strip()) and l.strip()[0] != "#"]
+except OSError:
+    # fall back gracefully
+    stubber.modules = ["micropython"]
+    _log.warning("Warning: modulelist.txt could not be found.")
+"""
+
+_LOW_MEM_MODULE_DOC = '''
+"""Create stubs for (all) modules on a MicroPython board.
+
+    This variant of the createstubs.py script is optimised for use on low-memory devices, and reads the list of modules from a text file 
+    `./modulelist.txt` that should be uploaded to the device.
+    If that cannot be found then only a single module (micropython) is stubbed.
+    In order to run this on low-memory devices two additioanl steps are recommended: 
+    - minifification, using python-minifier
+      to reduce overall size, and remove logging overhead.
+    - cross compilation, using mpy-cross, 
+      to avoid the compilation step on the micropython device 
+
+    you can find a cross-compiled version located here: ./minified/createstubs_mem.mpy
+"""
+'''
+
+_LVGL_MAIN = """
+# Specify firmware name & version
+try:
+    fw_id = "lvgl-{0}_{1}_{2}-{3}-{4}".format(
+        lvgl.version_major(),
+        lvgl.version_minor(),
+        lvgl.version_patch(),
+        lvgl.version_info(),
+        sys.platform,
+    )
+except Exception:
+    fw_id = "lvgl-{0}_{1}_{2}_{3}-{4}".format(8, 1, 0, "dev", sys.platform)
+    
+stubber = Stubber(firmware_id=fw_id)
+
+"""
+
+
+@unique
+class CreateStubsFlavor(Enum):
+    """Dictates create stubs target variant."""
+
+    BASE = auto()
+    LOW_MEM = auto()
+    LVGL = auto()
+
+
+class SimpleStatementReplace(m.MatcherDecoratableTransformer):
+    new_node: cst.SimpleStatementLine
+    scope_matcher: m.BaseMatcherNode
+
+    def __init__(self, new_node: cst.SimpleStatementLine, scope_matcher: Optional[m.BaseMatcherNode] = None):
+        self.new_node = new_node
+        self.scope_matcher = scope_matcher
+        if self.scope_matcher:
+            self.__class__ = type(
+                f"{self.__class__.__name__}_{repr(scope_matcher)}",
+                (self.__class__,),
+                {"replace_statement": m.call_if_inside(scope_matcher)(self.__class__.replace_statement)},
+            )
+        super().__init__()
+
+    @m.leave(m.SimpleStatementLine())
+    def replace_statement(self, _: cst.SimpleStatementLine, __: cst.SimpleStatementLine) -> cst.SimpleStatementLine:
+        return self.new_node
+
+
+class ReadModulesCodemod(codemod.Codemod):
+    """Replaces static modules list with file-load method."""
+
+    modules_reader_node: cst.SimpleStatementLine
+
+    def __init__(self, context: codemod.CodemodContext, reader_node: Optional[cst.SimpleStatementLine] = None):
+        super().__init__(context)
+        self.modules_reader_node = reader_node or cst.parse_statement(_MODULES_READER)
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        transform = SimpleStatementReplace(self.modules_reader_node, scope_matcher=m.SimpleStatementLine(body=[_MODULES_MATCHER]))
+        return tree.visit(transform)
+
+
+class ModuleDocCodemod(codemod.Codemod):
+    """Replaces a module's docstring."""
+
+    module_doc: str
+
+    def __init__(self, context: codemod.CodemodContext, module_doc: str):
+        super().__init__(context)
+        self.module_doc = module_doc
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        if not isinstance(self.module_doc, str):
+            raise TypeError(f"Expected module_doc to be of type str, received: {type(self.module_doc)}")
+        return update_module_docstr(tree, cst.parse_statement(self.module_doc))
+
+
+class LVGLCodemod(codemod.Codemod):
+    """Generates createstubs.py LVGL flavor."""
+
+    modules_changeset: ListChangeSet
+    init_node: cst.SimpleStatementLine
+
+    def __init__(
+        self,
+        context: codemod.CodemodContext,
+        modules_changeset: Optional[ListChangeSet] = None,
+        init_node: Optional[cst.SimpleStatementLine] = None,
+    ):
+        super().__init__(context)
+        self.modules_changeset = modules_changeset or ListChangeSet.from_strings(add=["io", "lodepng", "rtch", "lvgl"], replace=True)
+        self.init_node = init_node or cst.parse_module(_LVGL_MAIN)
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        modules_transform = ModifyListElements(change_set=self.modules_changeset, scope_matcher=_MODULES_MATCHER)
+        init_transform = SimpleStatementReplace(self.init_node, scope_matcher=m.SimpleStatementLine(body=[_STUBBER_MATCHER]))
+        tree = tree.visit(modules_transform)
+        return tree.visit(init_transform)
+
+
+class LowMemoryCodemod(codemod.Codemod):
+    """Generates createstubs.py low-memory flavor."""
+
+    def __init__(self, context: codemod.CodemodContext):
+        super().__init__(context)
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        doc_transformer = ModuleDocCodemod(self.context, _LOW_MEM_MODULE_DOC)
+        read_mods_transformer = ReadModulesCodemod(self.context)
+        tree = doc_transformer.transform_module(tree)
+        return read_mods_transformer.transform_module(tree)
+
+
+class CreateStubsCodemod(codemod.Codemod):
+    """Generates createstubs.py variant based on provided flavor."""
+
+    flavor: CreateStubsFlavor
+
+    def __init__(self, context: codemod.CodemodContext, flavor: CreateStubsFlavor = CreateStubsFlavor.BASE):
+        super().__init__(context)
+        self.flavor = flavor
+
+    def transform_module_impl(self, tree: cst.Module) -> cst.Module:
+        mod_flavors = {
+            CreateStubsFlavor.LVGL: LVGLCodemod,
+            CreateStubsFlavor.LOW_MEM: LowMemoryCodemod,
+        }
+        if self.flavor not in mod_flavors:
+            # just return base or unknown.
+            return tree
+        return mod_flavors[self.flavor](self.context).transform_module(tree)

--- a/src/stubber/codemod/board.py
+++ b/src/stubber/codemod/board.py
@@ -8,6 +8,7 @@ import libcst.codemod as codemod
 from libcst import matchers as m
 
 from stubber.codemod.modify_list import ModifyListElements, ListChangeSet
+from stubber.codemod.utils import ScopeableMatcherTransformer
 from stubber.cst_transformer import update_module_docstr
 
 _STUBBER_MATCHER = m.Assign(
@@ -141,13 +142,13 @@ class ModulesUpdateCodemod(codemod.Codemod):
         self.problematic_changeset = problematic
         self.excluded_changeset = excluded
 
-    def iter_transforms(self) -> Iterator[ModifyListElements]:
+    def iter_transforms(self) -> Iterator[ScopeableMatcherTransformer]:
         if self.modules_changeset:
-            yield ModifyListElements(change_set=self.modules_changeset, scope_matcher=self.modules_scope)
+            yield ModifyListElements(change_set=self.modules_changeset).with_scope(self.modules_scope)
         if self.problematic_changeset:
-            yield ModifyListElements(change_set=self.problematic_changeset, scope_matcher=self.problematic_scope)
+            yield ModifyListElements(change_set=self.problematic_changeset).with_scope(self.problematic_scope)
         if self.excluded_changeset:
-            yield ModifyListElements(change_set=self.excluded_changeset, scope_matcher=self.excluded_scope)
+            yield ModifyListElements(change_set=self.excluded_changeset).with_scope(self.excluded_scope)
 
     def transform_module_impl(self, tree: cst.Module) -> cst.Module:
         for transform in self.iter_transforms():

--- a/src/stubber/codemod/modify_list.py
+++ b/src/stubber/codemod/modify_list.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Sequence, Optional
+
+import libcst as cst
+from libcst import matchers as m
+
+
+@dataclass(kw_only=True)
+class ListChangeSet:
+    add: Sequence[cst.BaseExpression] = field(default_factory=list)
+    remove: Sequence[m.BaseMatcherNode] = field(default_factory=list)
+    replace: bool = False
+
+    @classmethod
+    def from_strings(
+        cls, *, add: Optional[Sequence[str]] = None, remove: Optional[Sequence[str]] = None, replace: bool = False
+    ) -> ListChangeSet:
+        add_nodes = [cst.SimpleString(f'"{s}"') for s in add] if add else []
+        remove_nodes = [m.SimpleString(f'"{s}"') for s in remove or list()] if remove else []
+        return ListChangeSet(add=add_nodes, remove=remove_nodes, replace=replace)
+
+
+class ModifyListElements(m.MatcherDecoratableTransformer):
+    scope_matcher: Optional[m.BaseMatcherNode]
+    change_set: ListChangeSet
+
+    def __init__(self, *, change_set: ListChangeSet, scope_matcher: Optional[m.BaseMatcherNode] = None):
+        self.scope_matcher = scope_matcher
+        self.change_set = change_set
+        if self.scope_matcher:
+            # create a dynamically derived class with the transform meth wrapped with scope check.
+            self.__class__ = type(
+                f"{self.__class__.__name__}_{repr(scope_matcher)}",
+                (self.__class__,),
+                {"modify_list_elements": m.call_if_inside(scope_matcher)(self.__class__.modify_list_elements)},
+            )
+        super().__init__()
+
+    @m.leave(m.List())
+    def modify_list_elements(self, original_node: cst.List, updated_node: cst.List) -> cst.List:
+        current_elements = [e.value for e in original_node.elements if not any(self.matches(e.value, r) for r in self.change_set.remove)]
+        new_elements = [] if self.change_set.replace else current_elements
+        new_elements.extend(self.change_set.add)
+
+        new_list = cst.List(elements=[cst.Element(value=cst.helpers.ensure_type(e, cst.BaseExpression)) for e in new_elements])
+
+        return updated_node.with_changes(elements=new_list.elements)

--- a/src/stubber/codemod/modify_list.py
+++ b/src/stubber/codemod/modify_list.py
@@ -7,7 +7,7 @@ import libcst as cst
 from libcst import matchers as m
 
 
-@dataclass(kw_only=True)
+@dataclass
 class ListChangeSet:
     add: Sequence[cst.BaseExpression] = field(default_factory=list)
     remove: Sequence[m.BaseMatcherNode] = field(default_factory=list)

--- a/src/stubber/codemod/modify_list.py
+++ b/src/stubber/codemod/modify_list.py
@@ -26,9 +26,9 @@ class ListChangeSet:
 class ModifyListElements(ScopeableMatcherTransformer):
     change_set: ListChangeSet
 
-    def __init__(self, *, change_set: ListChangeSet, scope_matcher: Optional[m.BaseMatcherNode] = None):
+    def __init__(self, *, change_set: ListChangeSet):
         self.change_set = change_set
-        super().__init__(scope_matcher=scope_matcher)
+        super().__init__()
 
     @m.leave(m.List())
     def modify_list_elements(self, original_node: cst.List, updated_node: cst.List) -> cst.List:

--- a/src/stubber/codemod/utils.py
+++ b/src/stubber/codemod/utils.py
@@ -10,17 +10,28 @@ class ScopeableMatcherTransformer(m.MatcherDecoratableTransformer):
 
     scope_matcher: Optional[m.BaseMatcherNode]
 
-    def __init__(self, *, scope_matcher: Optional[m.BaseMatcherNode] = None):
-        self.scope_matcher = scope_matcher
-        if self.scope_matcher is not None:
-            constructed_meths = list(
-                itertools.chain.from_iterable(
-                    [*_gather_constructed_leave_funcs(self).values(), *_gather_constructed_visit_funcs(self).values()]
-                )
-            )
-            scoped_meths = {
-                f.__name__: m.call_if_inside(self.scope_matcher)(getattr(self.__class__, f.__name__)) for f in constructed_meths
-            }
-            # create a dynamically derived class with the transform meth wrapped with scope check.
-            self.__class__ = type(f"{self.__class__.__name__}_{repr(self.scope_matcher)}", (self.__class__,), scoped_meths)
+    def __init__(self):
         super().__init__()
+
+    def _build_scoped_meth(self, method_name: str, scope_matcher: m.BaseMatcherNode):
+        """Build unbound scoped method from parent class."""
+        unbound_meth = getattr(type(self), method_name)
+        unbound_meth.__dict__.pop("_call_if_inside_matcher", None)
+        return m.call_if_inside(scope_matcher)(unbound_meth)
+
+    def with_scope(self, scope_matcher: m.BaseMatcherNode) -> m.MatcherDecoratableTransformer:
+        """Construct a copy of this matcher with visitors scoped to `scope_matcher.`"""
+        constructed_meths = list(
+            itertools.chain.from_iterable(
+                [*_gather_constructed_leave_funcs(self).values(), *_gather_constructed_visit_funcs(self).values()]
+            )
+        )
+        scoped_meths = {f.__name__: self._build_scoped_meth(f.__name__, scope_matcher) for f in constructed_meths}
+        inst_vars = {k: v for k, v in vars(self).items() if k not in {"_matchers", "_extra_leave_funcs", "_extra_visit_funcs"}}
+        # create a dynamically derived class with the transform meth wrapped with scope check.
+        klass = type(
+            f"{self.__class__.__name__}_{repr(scope_matcher)}",
+            (m.MatcherDecoratableTransformer,),
+            {**inst_vars, **scoped_meths, "scope_matcher": scope_matcher},
+        )
+        return klass()

--- a/src/stubber/codemod/utils.py
+++ b/src/stubber/codemod/utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from libcst import matchers as m
+from libcst.matchers._visitors import _gather_constructed_leave_funcs, _gather_constructed_visit_funcs
+from typing import Optional
+import itertools
+
+
+class ScopeableMatcherTransformer(m.MatcherDecoratableTransformer):
+    """MatcherDecoratableTransformer that can be reused with different scopes."""
+
+    scope_matcher: Optional[m.BaseMatcherNode]
+
+    def __init__(self, *, scope_matcher: Optional[m.BaseMatcherNode] = None):
+        self.scope_matcher = scope_matcher
+        if self.scope_matcher is not None:
+            constructed_meths = list(
+                itertools.chain.from_iterable(
+                    [*_gather_constructed_leave_funcs(self).values(), *_gather_constructed_visit_funcs(self).values()]
+                )
+            )
+            scoped_meths = {
+                f.__name__: m.call_if_inside(self.scope_matcher)(getattr(self.__class__, f.__name__)) for f in constructed_meths
+            }
+            # create a dynamically derived class with the transform meth wrapped with scope check.
+            self.__class__ = type(f"{self.__class__.__name__}_{repr(self.scope_matcher)}", (self.__class__,), scoped_meths)
+        super().__init__()

--- a/tests/codemods/test_board.py
+++ b/tests/codemods/test_board.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+import pytest
+import libcst as cst
+import libcst.codemod as codemod
+from pathlib import Path
+from textwrap import dedent
+
+import stubber.codemod.board as board
+from stubber.codemod.board import CreateStubsCodemod, CreateStubsFlavor
+from stubber.codemod.modify_list import ListChangeSet
+
+
+@pytest.fixture
+def create_stubs() -> cst.Module:
+    path = Path(__file__).parent.parent.parent / "board" / "createstubs.py"
+    return cst.parse_module(path.read_text())
+
+
+@pytest.fixture
+def context(create_stubs) -> tuple[codemod.CodemodContext, cst.Module]:
+    return codemod.CodemodContext(), create_stubs
+
+
+@pytest.fixture
+def low_memory_mod(context) -> CreateStubsCodemod:
+    return CreateStubsCodemod(context[0], flavor=CreateStubsFlavor.LOW_MEM)
+
+
+@pytest.fixture
+def low_memory_result(context, low_memory_mod) -> cst.Module:
+    return low_memory_mod.transform_module(context[1])
+
+
+def dedent_lines(body: str) -> str:
+    lines = [dedent(l) for l in body.splitlines(keepends=True)]
+    return "".join(lines)
+
+
+def compare_lines(excerpt: str, body: str) -> bool:
+    return dedent_lines(excerpt) in dedent_lines(body)
+
+
+def test_custom_modules(context):
+    ctx, cont = context
+    mod = CreateStubsCodemod(ctx, modules=ListChangeSet.from_strings(add=["mycustommodule"], replace=True)).transform_module(cont)
+    assert "mycustommodule" in mod.code
+
+
+# being problematic ironically.
+# something weird with codemod state and multiple visits
+# def test_custom_modules__problematic(context):
+#     res = CreateStubsCodemod(
+#         context[0],
+#         modules=ListChangeSet.from_strings(add=["coolmod"], replace=True),
+#         problematic=ListChangeSet.from_strings(add=["runt"], replace=True),
+#     ).transform_module(context[1])
+#     assert compare_lines('self.problematic = ["runt"]', res.code)
+
+
+def test_low_mem__module_doc(low_memory_result):
+    assert board._LOW_MEM_MODULE_DOC in low_memory_result.code
+
+
+def test_low_mem__read_stubs(low_memory_result):
+    assert compare_lines(board._MODULES_READER, low_memory_result.code)
+
+
+def test_low_mem__custom_modules(context):
+    # this reads from module list, so wont do anything
+    # but it shouldnt fail either.
+    res = CreateStubsCodemod(
+        context[0], flavor=CreateStubsFlavor.LOW_MEM, modules=ListChangeSet.from_strings(add=["supercoolmodule"], replace=True)
+    ).transform_module(context[1])
+    assert res.code
+    assert not compare_lines("'supercoolmodule'", res.code)
+
+
+def test_lvgl__init(context):
+    res = CreateStubsCodemod(context[0], flavor=CreateStubsFlavor.LVGL).transform_module(context[1])
+    assert compare_lines(board._LVGL_MAIN, res.code)
+
+
+def test_lvgl__modules_default(context):
+    res = CreateStubsCodemod(context[0], flavor=CreateStubsFlavor.LVGL).transform_module(context[1])
+    assert compare_lines('"io", "lodepng", "rtch", "lvgl"', res.code)
+
+
+def test_lvgl__modules_custom(context):
+    res = CreateStubsCodemod(
+        context[0], flavor=CreateStubsFlavor.LVGL, modules=ListChangeSet.from_strings(add=["supercoolmodule"], replace=True)
+    ).transform_module(context[1])
+    assert compare_lines('"supercoolmodule"', res.code)

--- a/tests/codemods/test_board.py
+++ b/tests/codemods/test_board.py
@@ -46,15 +46,15 @@ def test_custom_modules(context):
     assert "mycustommodule" in mod.code
 
 
-# being problematic ironically.
-# something weird with codemod state and multiple visits
-# def test_custom_modules__problematic(context):
-#     res = CreateStubsCodemod(
-#         context[0],
-#         modules=ListChangeSet.from_strings(add=["coolmod"], replace=True),
-#         problematic=ListChangeSet.from_strings(add=["runt"], replace=True),
-#     ).transform_module(context[1])
-#     assert compare_lines('self.problematic = ["runt"]', res.code)
+def test_custom_modules__problematic(context):
+    mod = CreateStubsCodemod(
+        context[0],
+        modules=ListChangeSet.from_strings(add=["coolmod"], replace=True),
+        problematic=ListChangeSet.from_strings(add=["runt"], replace=True),
+    )
+    res = mod.transform_module(context[1])
+    assert compare_lines('"runt"', res.code)
+    assert compare_lines('"coolmod"', res.code)
 
 
 def test_low_mem__module_doc(low_memory_result):

--- a/tests/codemods/test_board.py
+++ b/tests/codemods/test_board.py
@@ -33,6 +33,14 @@ def low_memory_mod(context) -> CreateStubsCodemod:
 def low_memory_result(context, low_memory_mod) -> cst.Module:
     return low_memory_mod.transform_module(context[1])
 
+@pytest.fixture
+def db_mod(context) -> CreateStubsCodemod:
+    return CreateStubsCodemod(context[0], flavor=CreateStubsFlavor.DB)
+
+@pytest.fixture
+def db_result(context, db_mod) -> cst.Module:
+    return db_mod.transform_module(context[1])
+
 
 def dedent_lines(body: str) -> str:
     lines = [dedent(l) for l in body.splitlines(keepends=True)]
@@ -108,3 +116,10 @@ def test_lvgl__modules_custom(context):
         context[0], flavor=CreateStubsFlavor.LVGL, modules=ListChangeSet.from_strings(add=["supercoolmodule"], replace=True)
     ).transform_module(context[1])
     assert compare_lines('"supercoolmodule"', res.code)
+
+
+def test_db__module_doc(db_result):
+    assert compare_lines('reads the list of modules', db_result.code)
+
+def test_db__entry(db_result):
+    assert compare_lines("was_running = True", db_result.code)

--- a/tests/codemods/test_board.py
+++ b/tests/codemods/test_board.py
@@ -9,6 +9,9 @@ import stubber.codemod.board as board
 from stubber.codemod.board import CreateStubsCodemod, CreateStubsFlavor
 from stubber.codemod.modify_list import ListChangeSet
 
+# mark all tests
+pytestmark = pytest.mark.codemod
+
 
 @pytest.fixture
 def create_stubs() -> cst.Module:

--- a/tests/codemods/test_board.py
+++ b/tests/codemods/test_board.py
@@ -57,6 +57,21 @@ def test_custom_modules__problematic(context):
     assert compare_lines('"coolmod"', res.code)
 
 
+def test_custom_modules__problematic_excluded(context):
+    mod = CreateStubsCodemod(
+        context[0],
+        modules=ListChangeSet.from_strings(add=["coolmod"], replace=True),
+        problematic=ListChangeSet.from_strings(add=["runt"], replace=True),
+        excluded=ListChangeSet.from_strings(remove=["webrepl", "_webrepl"], add=["myexclude"]),
+    )
+    res = mod.transform_module(context[1])
+    assert compare_lines('"runt"', res.code)
+    assert compare_lines('"coolmod"', res.code)
+    assert not compare_lines('"webrepl"', res.code)
+    assert not compare_lines('"_webrepl"', res.code)
+    assert compare_lines('"myexclude"', res.code)
+
+
 def test_low_mem__module_doc(low_memory_result):
     assert board._LOW_MEM_MODULE_DOC in low_memory_result.code
 

--- a/tests/codemods/test_modify_list.py
+++ b/tests/codemods/test_modify_list.py
@@ -1,0 +1,146 @@
+import pytest
+from libcst.codemod import CodemodTest
+import libcst as cst
+import libcst.matchers as m
+from stubber.codemod.modify_list import ListChangeSet, ModifyListElements
+from collections import namedtuple
+from textwrap import dedent
+
+# mark all tests
+pytestmark = pytest.mark.codemod
+
+
+Case = namedtuple("Case", ["before", "after", "changeset", "scope"], defaults=["", "", None, None])
+
+
+scenarios = {
+    "add_string_element": Case(
+        before="""
+        a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = ["foo", "bar", "foobar"]
+        """,
+        changeset=ListChangeSet.from_strings(add=["foobar"]),
+    ),
+    "add_string_element_replace": Case(
+        before="""
+        a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = ["foobar"]
+        """,
+        changeset=ListChangeSet.from_strings(add=["foobar"], replace=True),
+    ),
+    "remove_string_element": Case(
+        before="""
+        a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = ["foo"]
+        """,
+        changeset=ListChangeSet.from_strings(remove=["bar"]),
+    ),
+    # a technically valid case.
+    "remove_string_element_replace": Case(
+        before="""
+        a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = []
+        """,
+        changeset=ListChangeSet.from_strings(remove=["bar"], replace=True),
+    ),
+    "add_cst_node": Case(
+        before="""
+        a = "foo"
+        b = "bar"
+        c = ("foo", "bar")
+        a_list = [a, b]
+        """,
+        after="""
+        a = "foo"
+        b = "bar"
+        c = ("foo", "bar")
+        a_list = [a, b, c]
+        """,
+        changeset=ListChangeSet(add=[cst.Name("c")]),
+    ),
+    "remove_cst_node_match": Case(
+        before="""
+        a = "foo"
+        b = "bar"
+        c = ("foo", "bar")
+        a_list = [a, b, c]
+        """,
+        after="""
+        a = "foo"
+        b = "bar"
+        c = ("foo", "bar")
+        a_list = [a]
+        """,
+        changeset=ListChangeSet(remove=[m.Name("c"), m.Name("b")]),
+    ),
+    "add_scoped_string": Case(
+        before="""
+        a_list = ["other", "values"]
+        def main():
+            a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = ["other", "values"]
+        def main():
+            a_list = ["foo", "bar", "foobar"]
+        """,
+        changeset=ListChangeSet.from_strings(add=["foobar"]),
+        scope=m.FunctionDef(name=m.Name("main")),
+    ),
+    "remove_scoped_string": Case(
+        before="""
+        a_list = ["other", "values"]
+        def main():
+            a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = ["other", "values"]
+        def main():
+            a_list = ["foo"]
+        """,
+        changeset=ListChangeSet.from_strings(remove=["bar"]),
+        scope=m.FunctionDef(name=m.Name("main")),
+    ),
+    "handles_unmatched_remove": Case(
+        before="""
+        a_list = ["other", "values"]
+        def main():
+            a_list = ["foo", "bar"]
+        """,
+        after="""
+        a_list = ["other", "values"]
+        def main():
+            a_list = ["foo", "bar"]
+        """,
+        changeset=ListChangeSet.from_strings(remove=["abc123"]),
+        scope=m.FunctionDef(name=m.Name("main")),
+    ),
+}
+
+
+class TestModifyListElements:
+    before: str
+    after: str
+    changeset: ListChangeSet
+    scope: m.BaseMatcherNode
+
+    @pytest.fixture(params=[pytest.param(v, id=k) for k, v in scenarios.items()], autouse=True)
+    def scenario(self, request: pytest.FixtureRequest):
+        request.cls.before = dedent(request.param.before)
+        request.cls.after = dedent(request.param.after)
+        request.cls.changeset = request.param.changeset
+        request.cls.scope = request.param.scope
+
+    def test_scenario(self):
+        trans = ModifyListElements(change_set=self.changeset, scope_matcher=self.scope)
+        module = cst.parse_module(self.before)
+        result = module.visit(trans)
+        assert result.code == self.after

--- a/tests/codemods/test_modify_list.py
+++ b/tests/codemods/test_modify_list.py
@@ -140,7 +140,9 @@ class TestModifyListElements:
         request.cls.scope = request.param.scope
 
     def test_scenario(self):
-        trans = ModifyListElements(change_set=self.changeset, scope_matcher=self.scope)
+        trans = ModifyListElements(change_set=self.changeset)
+        if self.scope:
+            trans = trans.with_scope(self.scope)
         module = cst.parse_module(self.before)
         result = module.visit(trans)
         assert result.code == self.after


### PR DESCRIPTION
This PR adds multiple codemods for dynamically generating variations of createstubs.py with ease.

The core idea of this approach is to enable:

- A central singular createstubs.py source.
- Support multiple different flavors of this singular source through the means of codemods.
- Dynamically configure the static modules lists (along with problematic, excluded, etc.)
- Be able to easily tie up base createstubs.py -> any variants (i.e, lvgl) -> module list modifications -> minification -> cross-compilation in a dirt simple / automatic process.

This pr specifically is tailored towards the plumbing side of things, such as the codemods and such.
It still needs more tests, but I wanted to get some thoughts (@Josverl) before I continued any further.

Here is a sample of how it works in practice currently:

```python
import libcst as cst
import libcst.codemod as codemod
from pathlib import Path

from stubber.codemod.board import CreateStubsCodemod, CreateStubsFlavor
from stubber.codemod.modify_list import ListChangeSet

create_stubs = (Path.cwd() / 'board' / 'createstubs.py').read_text()

ctx = codemod.CodemodContext()
cs_module = cst.parse_module(create_stubs)

# Low memory createstubs.py
low_mem = CreateStubsCodemod(ctx, flavor=CreateStubsFlavor.LOW_MEM).transform_module(cs_module)

# custom modules (and skip defaults).
custom_modules = ListChangeSet.from_strings(add=["mycoolpackage", "othermodule"], replace=True)
custom = CreateStubsCodemod(ctx, modules=custom_modules).transform_module(cs_module)

print(custom.code)

```

<details>
<summary>Custom modules createstubs.py output</summary>

```python
"""
Create stubs for (all) modules on a MicroPython board
"""
# Copyright (c) 2019-2022 Jos Verlinde
# pylint: disable= invalid-name, missing-function-docstring, import-outside-toplevel, logging-not-lazy
import gc
import logging
import sys

import uos as os
from ujson import dumps

# from utime import sleep_us

__version__ = "1.9.11"
ENOENT = 2
_MAX_CLASS_LEVEL = 2  # Max class nesting
# # deal with ESP32 firmware specific implementations.
# try:
#     from machine import resetWDT  # type: ignore  - LoBo specific function
# except ImportError:
#     # machine.WDT.feed()
#     def resetWDT():
#         pass


class Stubber:
    "Generate stubs for modules in firmware"

    def __init__(self, path: str = None, firmware_id: str = None):  # type: ignore
        try:
            if os.uname().release == "1.13.0" and os.uname().version < "v1.13-103":
                raise NotImplementedError("MicroPython 1.13.0 cannot be stubbed")
        except AttributeError:
            pass

        self._log = logging.getLogger("stubber")
        self._report = []  # type: list[str]
        self.info = _info()
        gc.collect()
        if firmware_id:
            self._fwid = str(firmware_id).lower()
        else:
            self._fwid = "{family}-{ver}-{port}".format(**self.info).lower()
        self._start_free = gc.mem_free()  # type: ignore

        if path:
            if path.endswith("/"):
                path = path[:-1]
        else:
            path = get_root()

        self.path = "{}/stubs/{}".format(path, self.flat_fwid).replace("//", "/")
        self._log.debug(self.path)
        try:
            ensure_folder(path + "/")
        except OSError:
            self._log.error("error creating stub folder {}".format(path))
        self.problematic = [
            "upip",
            "upysh",
            "webrepl_setup",
            "http_client",
            "http_client_ssl",
            "http_server",
            "http_server_ssl",
        ]
        self.excluded = [
            "webrepl",
            "_webrepl",
            "port_diag",
            "example_sub_led.py",
            "example_pub_button.py",
        ]
        # there is no option to discover modules from micropython, list is read from an external file.
        self.modules = []

    def get_obj_attributes(self, item_instance: object):
        "extract information of the objects members and attributes"
        # name_, repr_(value), type as text, item_instance
        _result = []
        _errors = []
        self._log.debug("get attributes {} {}".format(repr(item_instance), item_instance))
        for name in dir(item_instance):
            try:
                val = getattr(item_instance, name)
                # name , item_repr(value) , type as text, item_instance, order
                try:
                    type_text = repr(type(val)).split("'")[1]
                except IndexError:
                    type_text = ""
                if type_text in ("int", "float", "str", "bool", "tuple", "list", "dict"):
                    order = 1
                elif type_text in ("function", "method"):
                    order = 2
                elif type_text in ("class"):
                    order = 3
                else:
                    order = 4
                _result.append((name, repr(val), repr(type(val)), val, order))
            except AttributeError as e:
                _errors.append("Couldn't get attribute '{}' from object '{}', Err: {}".format(name, item_instance, e))
        # remove internal __
        _result = sorted([i for i in _result if not (i[0].startswith("_"))], key=lambda x: x[4])
        gc.collect()
        return _result, _errors

    def add_modules(self, modules):
        "Add additional modules to be exported"
        self.modules = sorted(set(self.modules) | set(modules))

    def create_all_stubs(self):
        "Create stubs for all configured modules"
        self._log.info("Start micropython-stubber v{} on {}".format(__version__, self._fwid))
        gc.collect()
        for module_name in self.modules:
            self.create_one_stub(module_name)
        self._log.info("Finally done")

    def create_one_stub(self, module_name: str):
        if module_name in self.problematic:
            self._log.warning("Skip module: {:<25}        : Known problematic".format(module_name))
            return False
        if module_name in self.excluded:
            self._log.warning("Skip module: {:<25}        : Excluded".format(module_name))
            return False

        file_name = "{}/{}.py".format(self.path, module_name.replace(".", "/"))
        gc.collect()
        m1 = gc.mem_free()  # type: ignore
        self._log.info("Stub module: {:<25} to file: {:<70} mem:{:>5}".format(module_name, file_name, m1))
        result = False
        try:
            result = self.create_module_stub(module_name, file_name)
        except OSError:
            return False
        gc.collect()
        self._log.debug("Memory     : {:>20} {:>6X}".format(m1, m1 - gc.mem_free()))  # type: ignore
        return result

    def create_module_stub(self, module_name: str, file_name: str = None) -> bool:  # type: ignore
        """Create a Stub of a single python module

        Args:
        - module_name (str): name of the module to document. This module will be imported.
        - file_name (Optional[str]): the 'path/filename.py' to write to. If omitted will be created based on the module name.
        """
        if module_name in self.problematic:
            self._log.warning("SKIPPING problematic module:{}".format(module_name))
            return False

        if file_name is None:
            file_name = self.path + "/" + module_name.replace(".", "_") + ".py"

        if "/" in module_name:
            # for nested modules
            module_name = module_name.replace("/", ".")

        # import the module (as new_module) to examine it
        new_module = None
        try:
            new_module = __import__(module_name, None, None, ("*"))
        except ImportError:
            # move one line up to overwrite
            self._log.warning("{}Skip module: {:<25} {:<79}".format("\u001b[1A", module_name, "Module not found."))
            return False

        # Start a new file
        ensure_folder(file_name)
        with open(file_name, "w") as fp:
            # todo: improve header
            s = '"""\nModule: \'{0}\' on {1}\n"""\n# MCU: {2}\n# Stubber: {3}\n'.format(module_name, self._fwid, self.info, __version__)
            fp.write(s)
            fp.write("from typing import Any\n\n")
            self.write_object_stub(fp, new_module, module_name, "")

        self._report.append('{{"module": "{}", "file": "{}"}}'.format(module_name, file_name.replace("\\", "/")))

        if not module_name in ["os", "sys", "logging", "gc"]:
            # try to unload the module unless we use it
            try:
                del new_module
            except (OSError, KeyError):  # lgtm [py/unreachable-statement]
                self._log.warning("could not del new_module")
            try:
                del sys.modules[module_name]
            except KeyError:
                self._log.debug("could not del sys.modules[{}]".format(module_name))
        gc.collect()
        return True

    def write_object_stub(self, fp, object_expr: object, obj_name: str, indent: str, in_class: int = 0):
        "Write a module/object stub to an open file. Can be called recursive."
        gc.collect()
        if object_expr in self.problematic:
            self._log.warning("SKIPPING problematic module:{}".format(object_expr))
            return

        # self._log.debug("DUMP    : {}".format(object_expr))
        items, errors = self.get_obj_attributes(object_expr)

        if errors:
            self._log.error(errors)

        for item_name, item_repr, item_type_txt, item_instance, _ in items:
            # name_, repr_(value), type as text, item_instance, order
            # do not create stubs for these primitives
            if item_name in ["classmethod", "staticmethod", "BaseException", "Exception"]:
                continue
            # Class expansion only on first 3 levels (bit of a hack)
            if item_type_txt == "<class 'type'>" and len(indent) <= _MAX_CLASS_LEVEL * 4:
                self._log.debug("{0}class {1}:".format(indent, item_name))
                superclass = ""
                is_exception = (
                    item_name.endswith("Exception")
                    or item_name.endswith("Error")
                    or item_name
                    in [
                        "KeyboardInterrupt",
                        "StopIteration",
                        "SystemExit",
                    ]
                )
                if is_exception:
                    superclass = "Exception"
                s = "\n{}class {}({}):\n".format(indent, item_name, superclass)
                # s += indent + "    ''\n"
                if is_exception:
                    s += indent + "    ...\n"
                    fp.write(s)
                    return
                # write classdef
                fp.write(s)
                # first write the class literals and methods
                self._log.debug("# recursion over class {0}".format(item_name))
                self.write_object_stub(
                    fp,
                    item_instance,
                    "{0}.{1}".format(obj_name, item_name),
                    indent + "    ",
                    in_class + 1,
                )
                # close with the __init__ method to make sure that the literals are defined
                # Add __init__
                s = indent + "    def __init__(self, *argv, **kwargs) -> None:\n"
                s += indent + "        ...\n\n"
                fp.write(s)
            # Class Methods and functions
            elif "method" in item_type_txt or "function" in item_type_txt:
                self._log.debug("# def {1} function or method, type = '{0}'".format(item_type_txt, item_name))
                # module Function or class method
                # will accept any number of params
                # return type Any
                ret = "Any"
                first = ""
                # Self parameter only on class methods/functions
                if in_class > 0:
                    first = "self, "
                # class method - add function decoration
                if "bound_method" in item_type_txt or "bound_method" in item_repr:
                    s = "{}@classmethod\n".format(indent)
                    s += "{}def {}(cls, *args, **kwargs) -> {}:\n".format(indent, item_name, ret)
                else:
                    s = "{}def {}({}*args, **kwargs) -> {}:\n".format(indent, item_name, first, ret)
                # s += indent + "    ''\n" # EMPTY DOCSTRING
                s += indent + "    ...\n\n"
                fp.write(s)
                self._log.debug("\n" + s)
            # constants of known types & values
            elif item_type_txt == "<class 'module'>":
                # Skip imported modules
                # fp.write("# import {}\n".format(item_name))
                pass

            elif item_type_txt.startswith("<class '"):

                t = item_type_txt[8:-2]
                s = ""

                if t in ["str", "int", "float", "bool", "bytearray", "bytes"]:
                    # known type: use actual value
                    s = "{0}{1} = {2} # type: {3}\n".format(indent, item_name, item_repr, t)
                elif t in ["dict", "list", "tuple"]:
                    # dict, list , tuple: use empty value
                    ev = {"dict": "{}", "list": "[]", "tuple": "()"}
                    s = "{0}{1} = {2} # type: {3}\n".format(indent, item_name, ev[t], t)
                else:
                    # something else
                    if not t in ["object", "set", "frozenset"]:
                        # Possibly default others to item_instance object ?
                        # https://docs.python.org/3/tutorial/classes.html#item_instance-objects
                        t = "Any"
                    # Requires Python 3.6 syntax, which is OK for the stubs/pyi
                    s = "{0}{1} : {2} ## {3} = {4}\n".format(indent, item_name, t, item_type_txt, item_repr)
                fp.write(s)
                self._log.debug("\n" + s)
            else:
                # keep only the name
                self._log.debug("# all other, type = '{0}'".format(item_type_txt))
                fp.write("# all other, type = '{0}'\n".format(item_type_txt))

                fp.write(indent + item_name + " # type: Any\n")

        del items
        del errors
        try:
            del item_name, item_repr, item_type_txt, item_instance  # type: ignore
        except (OSError, KeyError, NameError):  # lgtm [py/unreachable-statement]
            pass

    @property
    def flat_fwid(self):
        "Turn _fwid from 'v1.2.3' into '1_2_3' to be used in filename"
        s = self._fwid
        # path name restrictions
        chars = " .()/\\:$"
        for c in chars:
            s = s.replace(c, "_")
        return s

    def clean(self, path: str = None):  # type: ignore
        "Remove all files from the stub folder"
        if path is None:
            path = self.path
        self._log.info("Clean/remove files in folder: {}".format(path))
        try:
            os.stat(path)  # TEMP workaround mpremote listdir bug -
            items = os.listdir(path)
        except (OSError, AttributeError):  # lgtm [py/unreachable-statement]
            # os.listdir fails on unix
            return
        for fn in items:
            item = "{}/{}".format(path, fn)
            try:
                os.remove(item)
            except OSError:
                try:  # folder
                    self.clean(item)
                    os.rmdir(item)
                except OSError:
                    pass

    def report(self, filename: str = "modules.json"):
        "create json with list of exported modules"
        self._log.info("Created stubs for {} modules on board {}\nPath: {}".format(len(self._report), self._fwid, self.path))
        f_name = "{}/{}".format(self.path, filename)
        gc.collect()
        try:
            # write json by node to reduce memory requirements
            with open(f_name, "w") as f:
                f.write("{")
                f.write(dumps({"firmware": self.info})[1:-1])
                f.write(",\n")
                f.write(dumps({"stubber": {"version": __version__}, "stubtype": "firmware"})[1:-1])
                f.write(",\n")
                f.write('"modules" :[\n')
                start = True
                for n in self._report:
                    if start:
                        start = False
                    else:
                        f.write(",\n")
                    f.write(n)
                f.write("\n]}")
            used = self._start_free - gc.mem_free()  # type: ignore
            self._log.info("Memory used: {0} Kb".format(used // 1024))
        except OSError:
            self._log.error("Failed to create the report.")


def ensure_folder(path: str):
    "Create nested folders if needed"
    i = start = 0
    while i != -1:
        i = path.find("/", start)
        if i != -1:
            if i == 0:
                p = path[0]
            else:
                p = path[0:i]
            # p = partial folder
            try:
                _ = os.stat(p)
            except OSError as e:
                # folder does not exist
                if e.args[0] == ENOENT:
                    try:
                        os.mkdir(p)
                    except OSError as e2:
                        # self._log.error("failed to create folder {}".format(p))
                        raise e2
                else:
                    # self._log.error("failed to create folder {}".format(p))
                    raise e
        # next level deep
        start = i + 1


def _info():
    "collect base information on this runtime"
    _n = sys.implementation.name  # type: ignore
    _p = sys.platform if not sys.platform.startswith("pyb") else "stm32"
    info = {
        "name": _n,  # - micropython
        "release": "0.0.0",  # mpy semver from sys.implementation or os.uname()release
        "version": "0.0.0",  # major.minor.0
        "build": "",  # parsed from version
        "sysname": "unknown",  # esp32
        "nodename": "unknown",  # ! not on all builds
        "machine": "unknown",  # ! not on all builds
        "family": _n,  # fw families, micropython , pycopy , lobo , pycom
        "platform": _p,  # port: esp32 / win32 / linux
        "port": _p,  # port: esp32 / win32 / linux
        "ver": "",  # short version
    }
    try:
        info["release"] = ".".join([str(n) for n in sys.implementation.version])
        info["version"] = info["release"]
        info["name"] = sys.implementation.name
        info["mpy"] = sys.implementation.mpy
    except AttributeError:
        pass

    if sys.platform not in ("unix", "win32"):
        try:
            u = os.uname()
            info["sysname"] = u[0]  # u.sysname
            info["nodename"] = u[1]  #  u.nodename
            info["release"] = u[2]  # u.release
            info["machine"] = u[4]  #  u.machine
            # parse micropython build info
            if " on " in u[3]:  # version
                s = u[3].split(" on ")[0]
                if info["sysname"] == "esp8266":
                    # esp8266 has no usable info on the release
                    if "-" in s:
                        v = s.split("-")[0]
                    else:
                        v = s
                    info["version"] = info["release"] = v.lstrip("v")
                try:
                    info["build"] = s.split("-")[1]
                except IndexError:
                    pass
        except (IndexError, AttributeError, TypeError):
            pass

    try:  # families
        from pycopy import const as _t  # type: ignore

        info["family"] = "pycopy"
        del _t
    except (ImportError, KeyError):
        pass
    try:  # families
        from pycom import FAT as _t  # type: ignore

        info["family"] = "pycom"
        del _t
    except (ImportError, KeyError):
        pass
    if info["platform"] == "esp32_LoBo":
        info["family"] = "loboris"
        info["port"] = "esp32"
    elif info["sysname"] == "ev3":
        # ev3 pybricks
        info["family"] = "ev3-pybricks"
        info["release"] = "1.0.0"
        try:
            # Version 2.0 introduces the EV3Brick() class.
            from pybricks.hubs import EV3Brick  # type: ignore

            info["release"] = "2.0.0"
        except ImportError:
            pass

    # version info
    if info["release"]:
        info["ver"] = "v" + info["release"].lstrip("v")
    if info["family"] == "micropython":
        if info["release"] and info["release"] >= "1.10.0" and info["release"].endswith(".0"):
            # drop the .0 for newer releases
            info["ver"] = info["release"][:-2]
        else:
            info["ver"] = info["release"]
        # add the build nr, but avoid a git commit-id
        if info["build"] != "" and len(info["build"]) < 4:
            info["ver"] += "-" + info["build"]
    if info["ver"][0] != "v":
        info["ver"] = "v" + info["ver"]
    # spell-checker: disable
    if "mpy" in info:  # mpy on some v1.11+ builds
        sys_mpy = int(info["mpy"])
        arch = [
            None,
            "x86",
            "x64",
            "armv6",
            "armv6m",
            "armv7m",
            "armv7em",
            "armv7emsp",
            "armv7emdp",
            "xtensa",
            "xtensawin",
        ][sys_mpy >> 10]
        if arch:
            info["arch"] = arch
    return info
    # spell-checker: enable


def get_root() -> str:
    "Determine the root folder of the device"
    try:
        c = os.getcwd()
    except (OSError, AttributeError):
        # unix port
        c = "."
    r = c
    for r in [c, "/sd", "/flash", "/", "."]:
        try:
            _ = os.stat(r)
            break
        except OSError:
            continue
    return r


def file_exists(filename: str):
    try:
        os.stat(filename)
        return True
    except OSError:
        return False


def show_help():
    print("-p, --path   path to store the stubs in, defaults to '.'")
    sys.exit(1)


def read_path() -> str:
    "get --path from cmdline. [unix/win]"
    path = ""
    if len(sys.argv) == 3:
        cmd = (sys.argv[1]).lower()
        if cmd in ("--path", "-p"):
            path = sys.argv[2]
        else:
            show_help()
    elif len(sys.argv) == 2:
        show_help()
    return path


def isMicroPython() -> bool:
    "runtime test to determine full or micropython"
    # pylint: disable=unused-variable,eval-used
    try:
        # either test should fail on micropython
        # a) https://docs.micropython.org/en/latest/genrst/syntax.html#spaces
        # Micropython : SyntaxError
        # a = eval("1and 0")  # lgtm [py/unused-local-variable]
        # Eval blocks some minification aspects

        # b) https://docs.micropython.org/en/latest/genrst/builtin_types.html#bytes-with-keywords-not-implemented
        # Micropython: NotImplementedError
        b = bytes("abc", encoding="utf8")  # type: ignore # lgtm [py/unused-local-variable]

        # c) https://docs.micropython.org/en/latest/genrst/core_language.html#function-objects-do-not-have-the-module-attribute
        # Micropython: AttributeError
        c = isMicroPython.__module__  # type: ignore # lgtm [py/unused-local-variable]
        return False
    except (NotImplementedError, AttributeError):
        return True


def main():

    stubber = Stubber(path=read_path())
    # stubber = Stubber(path="/sd")
    # Option: Specify a firmware name & version
    # stubber = Stubber(firmware_id='HoverBot v1.2.1')
    stubber.clean()
    # there is no option to discover modules from micropython, need to hardcode
    # below contains combined modules from  Micropython ESP8622, ESP32, Loboris, Pycom and ulab , lvgl
    # spell-checker: disable
    # modules to stub : 131
    stubber.modules = [
        "mycoolpackage", "othermodule"
    ]  # spell-checker: enable

    gc.collect()

    stubber.create_all_stubs()
    stubber.report()


if __name__ == "__main__" or isMicroPython():
    try:
        _log = logging.getLogger("stubber")
        logging.basicConfig(level=logging.INFO)
        # logging.basicConfig(level=logging.DEBUG)
    except NameError:
        pass
    if not file_exists("no_auto_stubber.txt"):
        main()
```


</details>
