### PR TITLE
Update Board stubber

### DIFF
--- a/src/stubber/board/createstubs.py
+++ b/src/stubber/board/createstubs.py
@@ -3,6 +3,7 @@ Create stubs for (all) modules on a MicroPython board
 """
 # Copyright (c) 2019-2023 Jos Verlinde
 # pylint: disable= invalid-name, missing-function-docstring, import-outside-toplevel, logging-not-lazy
+# sourcery skip: use-contextlib-suppress
 import gc
 import logging
 import os
@@ -541,16 +542,13 @@ def _info():  # type:() -> dict[str, str]
     if info["family"] == "ev3-pybricks":
         info["release"] = "2.0.0"
 
-    if info["family"] == "micropython":
-        if (
-            info["version"]
-            and info["version"].endswith(".0")
-            and info["version"]
-            >= "1.10.0"  # versions from 1.10.0 to 1.20.0 do not have a micro .0
-            and info["version"] <= "1.19.9"
-        ):
-            # drop the .0 for newer releases
-            info["version"] = info["version"][:-2]
+    if info["family"] == "micropython" and (
+                info["version"]
+                and info["version"].endswith(".0")
+                and info["version"] >= "1.10.0"  # versions from 1.10.0 to 1.20.0 do not have a micro .0
+                and info["version"] <= "1.19.9"
+            ):
+        info["version"] = info["version"][:-2]
 
     # spell-checker: disable
     if "mpy" in info and info["mpy"]:  # mpy on some v1.11+ builds

--- a/src/stubber/rst/output_dict.py
+++ b/src/stubber/rst/output_dict.py
@@ -79,10 +79,11 @@ class SourceDict(OrderedDict):
                 out += str(code)
         return out
 
-    def __add__(self, dict: SourceDict):
+    def __add__(self, other: SourceDict):
+        "Aallows instances of the SourceDict class to be added together using the + operator or the += operator."
         # sd = sd + function
         # sd += function
-        self.update({dict.name: dict})
+        self.update({other.name: other})
         return self
 
     def add_docstr(self, docstr: Union[str, List[str]], extra: int = 0):
@@ -227,7 +228,15 @@ class SourceDict(OrderedDict):
 
 class ModuleSourceDict(SourceDict):
     def __init__(self, name: str, indent=0, lf: str = "\n"):
-        "set correct order a module definition to allow adding class variables"
+        """The ModuleSourceDict class is used to represent a Python module as a dictionary of its components, 
+        such as its docstring, version, comments, imports, constants, classes, and functions. 
+        The class has several methods,  
+            sort() which sorts the components of the module in the correct order for a module definition to allow adding class variables, 
+            find() which finds a class node based on its name, 
+            classes() which returns a list of the class names in parent-child order, 
+            add_import() which adds a list of imports to the module. 
+        The __str__() method is also defined to return a string representation of the module.
+        """
         super().__init__(
             [
                 ("docstr", [EMPTY_DOCSTR]),

--- a/src/stubber/rst/reader.py
+++ b/src/stubber/rst/reader.py
@@ -782,7 +782,7 @@ class RSTWriter(RSTParser):
         return super().write_file(filename)
 
     def prepare_output(self):
-        "clean up some trailing spaces and commas"
+        "Remove trailing spaces and commas from the output."
         lines = str(self.output_dict).splitlines(keepends=True)
         self.output = lines
         for i in range(len(self.output)):


### PR DESCRIPTION
## board stubber

- [x] detect multiple boards
- [ ] run for a single board 
- [ ] integrate script into stubber
- [x] use `mpremote mount <folder>` to run script in (temp location)
- [x] handle success / restarts / timeouts 
    - [x] esp8266
    - [x] esp32
    - [x] stm32
    - [x] samd51
    - [x] rp2
- [x] Use detected boards info
- [x] run stub postprocessing 
- [x] copy stubs to stubs repo structure 
- [ ] add function to update boardinfo.csv / json from micropython repo

## createstubs 

- [x] Simplify port detection
- [x] Add board detection
- [x] Simplify logging / avoid ANSI characters
- [x] refactor functions/methods
- [x] support `mpremote mount <folder>`
- [x] support `mpremote mip install` into default location 'lib'