### PR TITLE
Fix bug in get-frozen when using version=latest

### DIFF
--- a/src/stubber/commands/get_frozen_cmd.py
+++ b/src/stubber/commands/get_frozen_cmd.py
@@ -47,6 +47,7 @@ def cli_get_frozen(
     if version:
         result = fetch_repos(version, CONFIG.mpy_path, CONFIG.mpy_lib_path)
         if not result:
+            log.error("Failed to fetch repos for version: {} for micropython folder: {} and micropython-lib folder: {}".format(version, CONFIG.mpy_path.as_posix(), CONFIG.mpy_lib_path.as_posix()))
             return -1
     else:
         version = utils.clean_version(git.get_local_tag(CONFIG.mpy_path.as_posix()) or "0.0")

--- a/src/stubber/utils/repos.py
+++ b/src/stubber/utils/repos.py
@@ -68,12 +68,12 @@ def read_micropython_lib_commits(filename: str = "data/micropython_tags.csv"):
     return version_commit
 
 
-def match_lib_with_mpy(version_tag: str, lib_path: Path):
+def match_lib_with_mpy(version_tag: str, lib_path: Path) -> Bool:
     micropython_lib_commits = read_micropython_lib_commits()
     # Make sure that the correct micropython-lib release is checked out
     #  check if micropython-lib has matching tags
     if version_tag == "latest":
-        git.checkout_commit("master", lib_path)
+        return git.checkout_commit("master", lib_path)
     elif Version(version_tag) >= Version("v1.20.0"):
         # TODO:if version is v1.12.0 or newer
         #   then use submodules to checkout the correct version of micropython-lib

--- a/src/stubber/utils/repos.py
+++ b/src/stubber/utils/repos.py
@@ -68,7 +68,7 @@ def read_micropython_lib_commits(filename: str = "data/micropython_tags.csv"):
     return version_commit
 
 
-def match_lib_with_mpy(version_tag: str, lib_path: Path) -> Bool:
+def match_lib_with_mpy(version_tag: str, lib_path: Path) -> bool:
     micropython_lib_commits = read_micropython_lib_commits()
     # Make sure that the correct micropython-lib release is checked out
     #  check if micropython-lib has matching tags


### PR DESCRIPTION
Return from match_lib_with_mpy when checking out 'latest'