### PR TITLE
Updated readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,8 +79,8 @@ cd my_stub_folder
 mkdir all-stubs
 
 # clone the micropython repo's and switch to a specific version 
-stubber clone
-stubber switch --version v1.18
+stubber clone --add-stubs
+stubber switch v1.22.2
 
 # get the document stubs for the current version ( v1.18 )
 stubber get-docstubs


### PR DESCRIPTION
I noticed that these two instructions in the README don't quite work. There's no `--version` switch:

```
$ stubber switch --version v1.22.2
18:52:09 | INFO     | cli                - micropython-stubber 1.20.1
Usage: stubber switch [OPTIONS] [[v1.10|v1.11|v1.12|v1.13|v1.14|v1.15|v1.16|v1
                      .17|v1.18|v1.19|v1.19.1|v1.20.0|v1.21.0|v1.22.0|v1.22.0-
                      preview|v1.22.1|v1.22.2|v1.23.0-preview|v1.9.3|v1.9.4|pr
                      eview|latest]]
Try 'stubber switch --help' for help.

Error: No such option: --version
```

And without adding `--add-stubs` to the `stubber clone` command, `stubber get-docstubs` fails:

```
$ stubber get-docstubs
18:51:40 | INFO     | cli                - micropython-stubber 1.20.1
Usage: stubber get-docstubs [OPTIONS]
Try 'stubber get-docstubs --help' for help.

Error: Invalid value for '--stub-path' / '--stub-folder': Directory 'repos/micropython-stubs/stubs' does not exist.
```