### PR TITLE
Add stub location summary at completion

### DIFF
--- a/src/stubber/bulk/mcu_stubber.py
+++ b/src/stubber/bulk/mcu_stubber.py
@@ -21,7 +21,7 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 from stubber import utils
 from stubber.publish.merge_docstubs import merge_all_docstubs
-from stubber.publish.pathnames import board_folder_name
+from stubber.publish.pathnames import board_folder_name, get_merged_path
 from stubber.publish.publish import build_multiple
 from stubber.utils.config import CONFIG
 
@@ -339,6 +339,9 @@ def stub_connected_mcus(
 
     show_mcus(connected_mcus, refresh=False)
 
+    # Track stub locations for final summary
+    stub_locations = []
+
     # scan boards and generate stubs
     for board in connected_mcus:
         log.info(f"Connecting using {board.serialport} to {board.port} {board.board} {board.version}: {board.description}")
@@ -353,6 +356,13 @@ def stub_connected_mcus(
             log.success(f"Stubs generated for {board.firmware['port']}-{board.firmware['board']}")
             if destination := copy_to_repo(my_stubs, board.firmware):
                 log.success(f"Stubs copied to {destination}")
+                # Track location for final summary
+                merged_path = get_merged_path(board.firmware)
+                stub_locations.append({
+                    'raw': destination,
+                    'merged': merged_path,
+                    'board': f"{board.firmware['port']}-{board.firmware['board']}"
+                })
                 # Also merge the stubs with the docstubs
                 log.info(f"Merging stubs with docstubs : {board.firmware}")
 
@@ -377,6 +387,16 @@ def stub_connected_mcus(
 
     if all_built:
         print_result_table(all_built)
+
+        # Print summary of stub locations
+        if stub_locations:
+            log.info("")
+            log.info("Stub locations:")
+            for loc in stub_locations:
+                log.info(f"  {loc['board']}:")
+                log.info(f"    Raw stubs:    {loc['raw']}")
+                log.info(f"    Merged stubs: {loc['merged']}")
+
         log.success("Done")
         return OK
     log.error(f"Failed to generate stubs for {board.serialport}")


### PR DESCRIPTION
As a first-time user of the tool I had no idea where the outputs were actually generated - took me a while to realise they went into the repos/micropython-stubs directory.

This MR displays a summary showing where stubs were generated after successful completion. 

Shows both raw stub paths and merged stub paths for each board processed, making it easier for users to find the generated files.