### PR TITLE
Ensure lib directory exists before mip_install

### DIFF
--- a/src/stubber/bulk/mcu_stubber.py
+++ b/src/stubber/bulk/mcu_stubber.py
@@ -73,13 +73,6 @@ def run_createstubs(
     Retry running the command up to 10 times, with a 15 second timeout between retries.
     this should allow for the boards with little memory to complete even if they run out of memory.
     """
-    # add the lib folder to the path
-    cmd_path = [
-        "exec",
-        'import sys;sys.path.append("/lib") if "/lib" not in sys.path else "/lib already in path"',
-    ]
-    mcu.run_command(cmd_path, timeout=5)
-
     if reset_before:
         log.info(f"Resetting {mcu.serialport} {mcu.description}")
         mcu.run_command("reset", timeout=5)
@@ -121,6 +114,29 @@ def build_cmd(dest: Union[Path, None], variant: Variant = Variant.db) -> List[st
     return cmd
 
 
+def ensure_lib_directory(mcu: MPRemoteBoard):
+    """
+    Create lib directory and add to sys.path for mip_install.
+
+    mpremote mip requires a lib path in sys.path but does not create the
+    directory itself. This must be called before mip_install.
+    """
+    cmd = [
+        "exec",
+        """
+import sys, os
+lib_path = os.getcwd() + '/lib'
+if lib_path not in sys.path:
+    sys.path.append(lib_path)
+try:
+    os.mkdir('lib')
+except OSError:
+    pass
+""".strip(),
+    ]
+    mcu.run_command(cmd, timeout=5)
+
+
 def generate_board_stubs(
     dest: Path,
     mcu: MPRemoteBoard,
@@ -144,6 +160,10 @@ def generate_board_stubs(
     if not mount_vfs:
         # remove prio stubs folder to avoid running out of flash space
         mcu.run_command(["rm", "-rv", ":stubs"], log_errors=False)
+
+    # Ensure lib directory exists and is in sys.path before mip_install
+    ensure_lib_directory(mcu)
+
     # HOST -> MCU : mip install createstubs to board
     ok = install_scripts_to_board(mcu, form)
     if not ok and not TESTING:


### PR DESCRIPTION
## Summary

Fix mip_install failure on boards where `/lib` directory doesn't exist by default.

## Problem

mpremote mip requires a path ending in `/lib` in `sys.path` to determine where to install packages, but does not create the directory itself. On boards without a pre-existing lib directory, `stubber mcu-stubs` fails with:

```
mpremote: Unable to find lib dir in sys.path
```

The existing code attempted to add `/lib` to `sys.path`, but had two issues:
1. **Wrong timing** - it ran in `run_createstubs()` which is called *after* `mip_install`, so the path wasn't set when needed
2. **Wrong path format** - used absolute `/lib` instead of `os.getcwd() + '/lib'` which mpremote expects (path must end with `/lib` but not start with `/rom`)

## Solution

Add `ensure_lib_directory()` which creates the lib directory and adds it to `sys.path` before `mip_install` is called. Uses `os.getcwd() + '/lib'` to match mpremote's path matching logic. Removes the now-redundant sys.path code from `run_createstubs()`.

## Test plan

- Run `stubber mcu-stubs` on a board without a pre-existing `/lib` directory
- Verify mip_install succeeds and stubs are generated